### PR TITLE
Fix: Allow VM disk sizes in Megabytes

### DIFF
--- a/netbox_pve_sync/__init__.py
+++ b/netbox_pve_sync/__init__.py
@@ -391,6 +391,8 @@ def _process_pve_disk_size(_raw_disk_size: str) -> int:
     size = _raw_disk_size[:-1]
     size_unit = _raw_disk_size[-1]
 
+    if size_unit == 'M':
+        return int(size)
     if size_unit == 'G':
         return int(size) * 1_000
     if size_unit == 'T':


### PR DESCRIPTION
Found a VM in my cluster with a megabytes-sized disk, which failed with:

`pynetbox.core.query.RequestError: The request failed with code 400 Bad Request: {'size': ['Ensure this value is greater than or equal to 0.']}`

This PR fixes that.