### PR TITLE
[PATCH] Import vCPU core count instead of total available cores

### DIFF
--- a/netbox_pve_sync/__init__.py
+++ b/netbox_pve_sync/__init__.py
@@ -130,7 +130,7 @@ def _process_pve_virtual_machine(
             site=_nb_device.site.id,
             cluster=os.environ.get('NB_CLUSTER_ID', 1),
             device=_nb_device.id,
-            vcpus=pve_virtual_machine_config['cores'],
+            vcpus=pve_virtual_machine_config['vcpus'] if 'vcpus' in pve_virtual_machine_config else pve_virtual_machine_config['cores'],
             memory=int(pve_virtual_machine_config['memory']),
             status='active' if _pve_virtual_machine['status'] == 'running' else 'offline',
             tags=list(map(lambda _pve_tag_name: _nb_objects['tags'][_pve_tag_name].id, _pve_tags)),
@@ -145,7 +145,7 @@ def _process_pve_virtual_machine(
         nb_virtual_machine.site = _nb_device.site.id
         nb_virtual_machine.cluster = os.environ.get('NB_CLUSTER_ID', 1)
         nb_virtual_machine.device = _nb_device.id
-        nb_virtual_machine.vcpus = pve_virtual_machine_config['cores']
+        nb_virtual_machine.vcpus = pve_virtual_machine_config['vcpus'] if 'vcpus' in pve_virtual_machine_config else pve_virtual_machine_config['cores']
         nb_virtual_machine.memory = int(pve_virtual_machine_config['memory'])
         nb_virtual_machine.status = 'active' if _pve_virtual_machine['status'] == 'running' else 'offline'
         nb_virtual_machine.tags = list(map(lambda _pve_tag_name: _nb_objects['tags'][_pve_tag_name].id, _pve_tags))


### PR DESCRIPTION
First of all, thank you for this project, it's very nice to have this automated coupling between PVE and Netbox! :)

The VMs I import all have CPU hotplugging enabled and most of them have only a few cores enabled of all available, e.g.:

<img width="700" height="224" alt="Image" src="https://github.com/user-attachments/assets/b67beb1c-b45c-416b-8838-cbf486fb03c0" />

(Note `Cores` vs. `VCPUs`)


As I imported VMs I noticed that in Netbox, the number of available CPU cores (`Cores`) are imported, instead of the `VCPUs` cores seen by the VM.

I fixed that locally, but I'm not an experienced Python developer, so here's my foolish attempt. I hope you get the idea, and feel free to merge or adapt.
